### PR TITLE
DB 연결 및 User model, schema 생성

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+SERVER_PORT = 5000
+DB_URL = 'mongodb+srv://admin:1234@cluster0.dkkrg.mongodb.net/myFirstDatabase?retryWrites=true&w=majority'

--- a/package-lock.json
+++ b/package-lock.json
@@ -147,6 +147,15 @@
         "@types/node": "*"
       }
     },
+    "@types/mongoose": {
+      "version": "5.10.5",
+      "resolved": "https://registry.npmjs.org/@types/mongoose/-/mongoose-5.10.5.tgz",
+      "integrity": "sha512-37QMIA954T3n+HSksSNLlxZsqF8fMJu5S4dyPBod6gRxGtsXlQ9jUtL8BE8Seimv99u79eLXI3bggoCnSQ/fxQ==",
+      "requires": {
+        "@types/mongodb": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/node": {
       "version": "14.14.37",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
@@ -680,6 +689,11 @@
       "requires": {
         "is-obj": "^2.0.0"
       }
+    },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -1958,6 +1972,14 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
+    },
+    "type-dotenv": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/type-dotenv/-/type-dotenv-1.0.0-beta.2.tgz",
+      "integrity": "sha512-i9CuogK6h59EkLFZ/CSeG/TVeq0BOT1rPBuQLnIGnmQOrcUgd+oQH6c1S5nLPJoBtR8FOAf6tYPg2zmfaKAtgA==",
+      "requires": {
+        "dotenv": "^8.2.0"
+      }
     },
     "type-fest": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,11 @@
     "typescript": "^4.2.4"
   },
   "dependencies": {
+    "@types/mongoose": "^5.10.5",
     "cors": "^2.8.5",
+    "dotenv": "^8.2.0",
     "express": "^4.17.1",
-    "mongoose": "^5.12.3"
+    "mongoose": "^5.12.3",
+    "type-dotenv": "^1.0.0-beta.2"
   }
 }

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import { SERVER_PORT } from './config/env';
 import './db';
 import User from './model/User/User';
 
@@ -18,7 +19,6 @@ const ProjectRouter = require('./routes/Project');
 app.use('/api/users', UserRouter);
 app.use('/api/project', ProjectRouter);
 
-const port = process.env.PORT || 5000;
-app.listen(port, () => {
-  console.log(`Server listnening on ${port}`);
+app.listen(SERVER_PORT, () => {
+  console.log(`Server listnening on ${SERVER_PORT}`);
 });

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import './db';
-import User from './model/User';
+import User from './model/User/User';
 
 const app = express();
 app.use(express.json());

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,31 +1,23 @@
 import express from 'express';
+import './db';
 
 const app = express();
 app.use(express.json());
-const cors=require('cors');
+const cors = require('cors');
 app.use(cors());
 
-const fs=require('fs');
+const fs = require('fs');
 
-// const config = require("./config/key");
-// const mongoose = require("mongoose");
-// const connect = mongoose.connect(config.mongoURI,
-//     {
-//     useNewUrlParser: true, useUnifiedTopology: true,
-//     useCreateIndex: true, useFindAndModify: false
-//     }).then(()=>console.log('MongoDB Connected..'))
-//       .catch((err:any) => console.log(err));
-
-app.get('/',(req:express.Request, res: express.Response)=>{
-    res.send('hello typescript!');
+app.get('/', (req: express.Request, res: express.Response) => {
+  res.send('hello typescript!');
 });
 
 const UserRouter = require('./routes/User');
 const ProjectRouter = require('./routes/Project');
-app.use('/api/users',UserRouter);
-app.use('/api/project',ProjectRouter);
+app.use('/api/users', UserRouter);
+app.use('/api/project', ProjectRouter);
 
 const port = process.env.PORT || 5000;
 app.listen(port, () => {
-    console.log(`Server listnening on ${port}`);
+  console.log(`Server listnening on ${port}`);
 });

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,5 +1,14 @@
 import express from 'express';
 import './db';
+import User from './model/User';
+
+const createUser = async () => {
+  await User.create({
+    nickname: 'test2',
+    email: 'test2@google.com',
+  });
+};
+createUser();
 
 const app = express();
 app.use(express.json());

--- a/server/app.ts
+++ b/server/app.ts
@@ -2,14 +2,6 @@ import express from 'express';
 import './db';
 import User from './model/User';
 
-const createUser = async () => {
-  await User.create({
-    nickname: 'test2',
-    email: 'test2@google.com',
-  });
-};
-createUser();
-
 const app = express();
 app.use(express.json());
 const cors = require('cors');

--- a/server/config/env.ts
+++ b/server/config/env.ts
@@ -1,0 +1,5 @@
+import dotenv from 'dotenv';
+dotenv.config();
+
+export const SERVER_PORT: number = +process.env.SERVER_PORT!;
+export const DB_URL: string = process.env.DB_URL!;

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,32 +1,12 @@
 import mongoose from 'mongoose';
+import { DB_URL } from './config/env';
 
 const connect = mongoose
-  .connect(
-    'mongodb+srv://admin:1234@cluster0.dkkrg.mongodb.net/myFirstDatabase?retryWrites=true&w=majority',
-    {
-      useNewUrlParser: true,
-      useUnifiedTopology: true,
-      useCreateIndex: true,
-      useFindAndModify: false,
-    }
-  )
+  .connect(DB_URL, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+    useCreateIndex: true,
+    useFindAndModify: false,
+  })
   .then(() => console.log('MongoDB Connected'))
   .catch((err: any) => console.log(err));
-
-// mongoose.connect('mongodb://127.0.0.1:27017/study-with', {
-//   useNewUrlParser: true,
-//   useUnifiedTopology: true,
-//   useCreateIndex: true,
-//   useFindAndModify: false,
-// });
-
-// const studyWithDB = mongoose.connection;
-
-// const handleOpen = () => {
-//   console.log('Connected to Study-with DB!!');
-// };
-// const handleError = (error: any) =>
-//   console.log(`Error on DB connection: ${error}`);
-
-// studyWithDB.once('open', handleOpen);
-// studyWithDB.on('error', handleError);

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,12 +1,15 @@
 import mongoose from 'mongoose';
 
 const connect = mongoose
-  .connect('mongodb://127.0.0.1:27017/study-with', {
-    useNewUrlParser: true,
-    useUnifiedTopology: true,
-    useCreateIndex: true,
-    useFindAndModify: false,
-  })
+  .connect(
+    'mongodb+srv://admin:1234@cluster0.dkkrg.mongodb.net/myFirstDatabase?retryWrites=true&w=majority',
+    {
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+      useCreateIndex: true,
+      useFindAndModify: false,
+    }
+  )
   .then(() => console.log('MongoDB Connected'))
   .catch((err: any) => console.log(err));
 

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,29 +1,29 @@
 import mongoose from 'mongoose';
 
-mongoose.connect('mongodb://127.0.0.1:27017/study-with', {
-  useNewUrlParser: true,
-  useUnifiedTopology: true,
-  useCreateIndex: true,
-  useFindAndModify: false,
-});
+const connect = mongoose
+  .connect('mongodb://127.0.0.1:27017/study-with', {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+    useCreateIndex: true,
+    useFindAndModify: false,
+  })
+  .then(() => console.log('MongoDB Connected'))
+  .catch((err: any) => console.log(err));
 
-const studyWithDB = mongoose.connection;
+// mongoose.connect('mongodb://127.0.0.1:27017/study-with', {
+//   useNewUrlParser: true,
+//   useUnifiedTopology: true,
+//   useCreateIndex: true,
+//   useFindAndModify: false,
+// });
 
-const handleOpen = () => {
-  console.log('Connected to Study-with DB!!');
-};
-const handleError = (error: any) =>
-  console.log(`Error on DB connection: ${error}`);
+// const studyWithDB = mongoose.connection;
 
-studyWithDB.once('open', handleOpen);
-studyWithDB.on('error', handleError);
+// const handleOpen = () => {
+//   console.log('Connected to Study-with DB!!');
+// };
+// const handleError = (error: any) =>
+//   console.log(`Error on DB connection: ${error}`);
 
-// const connect = mongoose
-//   .connect('mongodb://127.0.0.1:27017/study-with', {
-//     useNewUrlParser: true,
-//     useUnifiedTopology: true,
-//     useCreateIndex: true,
-//     useFindAndModify: false,
-//   })
-//   .then(() => console.log('MongoDB Connected..'))
-//   .catch((err: any) => console.log(err));
+// studyWithDB.once('open', handleOpen);
+// studyWithDB.on('error', handleError);

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,0 +1,29 @@
+import mongoose from 'mongoose';
+
+mongoose.connect('mongodb://127.0.0.1:27017/study-with', {
+  useNewUrlParser: true,
+  useUnifiedTopology: true,
+  useCreateIndex: true,
+  useFindAndModify: false,
+});
+
+const studyWithDB = mongoose.connection;
+
+const handleOpen = () => {
+  console.log('Connected to Study-with DB!!');
+};
+const handleError = (error: any) =>
+  console.log(`Error on DB connection: ${error}`);
+
+studyWithDB.once('open', handleOpen);
+studyWithDB.on('error', handleError);
+
+// const connect = mongoose
+//   .connect('mongodb://127.0.0.1:27017/study-with', {
+//     useNewUrlParser: true,
+//     useUnifiedTopology: true,
+//     useCreateIndex: true,
+//     useFindAndModify: false,
+//   })
+//   .then(() => console.log('MongoDB Connected..'))
+//   .catch((err: any) => console.log(err));

--- a/server/model/User.ts
+++ b/server/model/User.ts
@@ -1,44 +1,54 @@
 import mongoose from 'mongoose';
 
-const userSchema = new mongoose.Schema({
-  avartarImg: String,
-  nickname: {
-    type: String,
-    required: 'Nickname is required.',
-  },
-  email: {
-    type: String,
-    required: 'Email is required.',
-  },
-  tel: String,
-  job: String,
-  jobLevel: String,
+const userSchema = new mongoose.Schema(
+  {
+    avartarImg: String,
+    nickname: {
+      type: String,
+      required: 'Nickname is required.',
+      trim: true,
+      unique: true,
+    },
+    email: {
+      type: String,
+      required: 'Email is required.',
+      trim: true,
+      unique: true,
+    },
+    tel: {
+      type: String,
+      trim: true,
+      unique: true,
+    },
+    job: String,
+    jobLevel: String,
 
-  availableLocation: String,
-  availableWeek: String,
-  availableTime: String,
-  learningPeriod: String,
+    availableLocation: String,
+    availableWeek: String,
+    availableTime: String,
+    learningPeriod: String,
 
-  interestSkills: [String],
-  joinDate: {
-    type: Date,
-    default: Date.now,
+    interestSkills: [String],
+
+    intro: String,
+    portfolio: [String],
+
+    role: [
+      {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'Project',
+      },
+    ],
+    receivedLike: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Like',
+    },
+    token: String,
   },
-  intro: String,
-  portfolio: [String],
-
-  // role: [
-  //   {
-  //     type: mongoose.Schema.Types.ObjectId,
-  //     ref: 'Project',
-  //   },
-  // ],
-  // receivedLike: {
-  //   type: mongoose.Schema.Types.ObjectId,
-  //   ref: 'Like',
-  // },
-  token: String,
-});
+  {
+    timestamps: true,
+  }
+);
 
 const model = mongoose.model('User', userSchema);
 

--- a/server/model/User.ts
+++ b/server/model/User.ts
@@ -33,6 +33,10 @@ const userSchema = new mongoose.Schema({
   //     ref: 'Project',
   //   },
   // ],
+  // receivedLike: {
+  //   type: mongoose.Schema.Types.ObjectId,
+  //   ref: 'Like',
+  // },
   token: String,
 });
 

--- a/server/model/User.ts
+++ b/server/model/User.ts
@@ -1,0 +1,41 @@
+import mongoose from 'mongoose';
+
+const userSchema = new mongoose.Schema({
+  avartarImg: String,
+  nickname: {
+    type: String,
+    required: 'Nickname is required.',
+  },
+  email: {
+    type: String,
+    required: 'Email is required.',
+  },
+  tel: String,
+  job: String,
+  jobLevel: String,
+
+  availableLocation: String,
+  availableWeeik: String,
+  availableTime: String,
+  learningPeriod: String,
+
+  interestSkills: [String],
+  joinDate: {
+    type: Date,
+    default: Date.now,
+  },
+  intro: String,
+  portfolio: [String],
+
+  // role: [
+  //   {
+  //     type: mongoose.Schema.Types.ObjectId,
+  //     ref: 'Project',
+  //   },
+  // ],
+  token: String,
+});
+
+const model = mongoose.model('User', userSchema);
+
+export default model;

--- a/server/model/User.ts
+++ b/server/model/User.ts
@@ -15,7 +15,7 @@ const userSchema = new mongoose.Schema({
   jobLevel: String,
 
   availableLocation: String,
-  availableWeeik: String,
+  availableWeek: String,
   availableTime: String,
   learningPeriod: String,
 

--- a/server/model/User/User.ts
+++ b/server/model/User/User.ts
@@ -19,7 +19,6 @@ const userSchema: mongoose.Schema = new mongoose.Schema(
     tel: {
       type: String,
       trim: true,
-      unique: true,
     },
     position: String,
     positionLevel: String,
@@ -31,7 +30,6 @@ const userSchema: mongoose.Schema = new mongoose.Schema(
     receivedLike: {
       type: mongoose.Schema.Types.ObjectId,
       ref: 'Like',
-      default: 0,
     },
     join: [
       {

--- a/server/model/User/User.ts
+++ b/server/model/User/User.ts
@@ -21,30 +21,32 @@ const userSchema: mongoose.Schema = new mongoose.Schema(
       trim: true,
       unique: true,
     },
-    job: String,
-    jobLevel: String,
-
+    position: String,
+    positionLevel: String,
     availableLocation: String,
     availableWeek: String,
     availableTime: String,
-    learningPeriod: String,
-
     interestSkills: [String],
-
-    intro: String,
-    portfolio: [String],
-
+    token: String,
+    receivedLike: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Like',
+      default: 0,
+    },
+    join: [
+      {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'Project',
+      },
+    ],
     role: [
       {
         type: mongoose.Schema.Types.ObjectId,
         ref: 'Project',
       },
     ],
-    receivedLike: {
-      type: mongoose.Schema.Types.ObjectId,
-      ref: 'Like',
-    },
-    token: String,
+    portfolio: [String],
+    intro: String,
   },
   {
     timestamps: true,

--- a/server/model/User/User.ts
+++ b/server/model/User/User.ts
@@ -1,6 +1,7 @@
 import mongoose from 'mongoose';
+import IUser from './UserInterface';
 
-const userSchema = new mongoose.Schema(
+const userSchema: mongoose.Schema = new mongoose.Schema(
   {
     avartarImg: String,
     nickname: {
@@ -50,6 +51,6 @@ const userSchema = new mongoose.Schema(
   }
 );
 
-const model = mongoose.model('User', userSchema);
+const model: mongoose.Model<IUser> = mongoose.model('User', userSchema);
 
 export default model;

--- a/server/model/User/UserInterface.ts
+++ b/server/model/User/UserInterface.ts
@@ -1,0 +1,21 @@
+import { Date, Document } from 'mongoose';
+
+export default interface IUser extends Document {
+  avartarImg: string;
+  nickname: string;
+  email: string;
+  tel: string;
+  job: string;
+  jobLevel: string;
+  availableLocation: string;
+  availableWeek: string;
+  availableTime: string;
+  learningPeriod: string;
+  interestSkills: string[];
+  portfolio: string[];
+  receivedLike: number;
+  token: string;
+  timestamps: Date;
+  intro?: string;
+  role?: string;
+}

--- a/server/model/User/UserInterface.ts
+++ b/server/model/User/UserInterface.ts
@@ -1,21 +1,22 @@
-import { Date, Document } from 'mongoose';
+import { Date, Document, Schema } from 'mongoose';
 
 export default interface IUser extends Document {
   avartarImg: string;
   nickname: string;
   email: string;
   tel: string;
-  job: string;
-  jobLevel: string;
+  position: string;
+  positionLevel: string;
   availableLocation: string;
   availableWeek: string;
   availableTime: string;
-  learningPeriod: string;
   interestSkills: string[];
-  portfolio: string[];
-  receivedLike: number;
   token: string;
-  timestamps: Date;
+  receivedLike: number;
+  createdAt: Date;
+  updatedAt: Date;
+  join?: string;
+  role?: string[];
+  portfolio?: string[];
   intro?: string;
-  role?: string;
 }

--- a/server/model/User/UserInterface.ts
+++ b/server/model/User/UserInterface.ts
@@ -4,7 +4,6 @@ export default interface IUser extends Document {
   avartarImg: string;
   nickname: string;
   email: string;
-  tel: string;
   position: string;
   positionLevel: string;
   availableLocation: string;
@@ -15,6 +14,7 @@ export default interface IUser extends Document {
   receivedLike: number;
   createdAt: Date;
   updatedAt: Date;
+  tel?: string;
   join?: string;
   role?: string[];
   portfolio?: string[];


### PR DESCRIPTION
## 개요

- DB 연결 및 User model, schema 생성
 
## 작업 내용

- 'study-with' DB 생성
- User schema, model 생성
   - nickname, email 항목만 필수 값, 나머지 값은 옵션 값으로 설정
   - avartarImg
      - avatar -> avatarImg 이름 변경
   - tel
      - 추가
   - job
   - jobLevel
     - status -> jobLevel 이름 변경
   - availableLocation, availableWeek, availableTime
     - 회의 관련 값 추가
   - learningPeriod
     - learning -> learningPeriod 이름 변경
   - interestSkills
     - skills -> interestSkills 이름 변경
   - joinDate
   - intro
   - portfolio
   - role
     - objectID type 사용
   - receivedLike
     - objectID type 사용
   - token

* ##### 차주에 myPage, people 등 user 정보가 들어가는 페이지 markup 수정이 필요할 것으로 보임

## 스크린샷

#### DB 연결 확인
![db 연결 성공 확인1](https://user-images.githubusercontent.com/31345532/116504830-38997600-a8f4-11eb-8c0c-7beeb2db18a2.png)

#### 저장한 user 값 확인
![db 데이터 저장](https://user-images.githubusercontent.com/31345532/116504825-36371c00-a8f4-11eb-8e39-17e358993bd0.PNG)

#### Atals DB
![image](https://user-images.githubusercontent.com/31345532/116785853-b026fb00-aad6-11eb-9905-778bd4e0e09f.png)
