### PR TITLE
유저 & 프로젝트 좋아요 기능 추가

### DIFF
--- a/client/src/Components/Common/LikeButton.tsx
+++ b/client/src/Components/Common/LikeButton.tsx
@@ -24,29 +24,22 @@ const HeartBtn = styled.div<{ isLike: boolean }>`
 interface IProps {
   isProject: boolean;
   userId: null | string;
-  projectId: null | string;
-  recieveduserId: null | string;
+  targetId: null | string;
   setLike: React.Dispatch<React.SetStateAction<number>>;
 }
 
-const LikeButton = ({
-  isProject,
-  userId,
-  projectId,
-  recieveduserId,
-  setLike,
-}: IProps) => {
+const LikeButton = ({ isProject, userId, targetId, setLike }: IProps) => {
   const [isLike, setIsLike] = useState(false);
   let formData = {};
 
   if (isProject) {
     formData = {
-      projectId,
+      projectId: targetId,
       userId,
     };
   } else {
     formData = {
-      recieveduserId,
+      recieveduserId: targetId,
       userId,
     };
   }

--- a/client/src/Components/Common/LikeButton.tsx
+++ b/client/src/Components/Common/LikeButton.tsx
@@ -5,6 +5,7 @@ import emptyHeart from '../../img/empty-heart.svg';
 import borderHeart from '../../img/border-heart.svg';
 import axios from 'axios';
 import { LIKE_SERVER } from '../../Config';
+import { ILike } from '../../../../server/models/Like.interface';
 
 const HeartBtn = styled.div<{ isLike: boolean }>`
   width: 24px;
@@ -92,7 +93,8 @@ const LikeButton = ({ isProject, userId, targetId, setLike }: IProps) => {
         const {
           data: { likes },
         } = await axios.post(`${LIKE_SERVER}/getLike`, formData);
-        likes.forEach((like: any) => {
+        likes.forEach((like: ILike) => {
+          console.log(like);
           if (like.SenduserId === userId) {
             setIsLike(true);
           }

--- a/client/src/Components/Common/LikeButton.tsx
+++ b/client/src/Components/Common/LikeButton.tsx
@@ -38,6 +38,7 @@ const LikeButton = ({
 }: IProps) => {
   const [isLike, setIsLike] = useState(false);
   let formData = {};
+
   if (isProject) {
     formData = {
       projectId,
@@ -49,7 +50,7 @@ const LikeButton = ({
       userId,
     };
   }
-  console.log(formData);
+
   const handleUplike = async () => {
     try {
       const {

--- a/client/src/Components/Common/LikeButton.tsx
+++ b/client/src/Components/Common/LikeButton.tsx
@@ -94,7 +94,6 @@ const LikeButton = ({ isProject, userId, targetId, setLike }: IProps) => {
           data: { likes },
         } = await axios.post(`${LIKE_SERVER}/getLike`, formData);
         likes.forEach((like: ILike) => {
-          console.log(like);
           if (like.SenduserId === userId) {
             setIsLike(true);
           }

--- a/client/src/Components/Common/LikeButton.tsx
+++ b/client/src/Components/Common/LikeButton.tsx
@@ -25,10 +25,17 @@ interface IProps {
   isProject: boolean;
   userId: null | string;
   projectId: null | string;
+  recieveduserId: null | string;
   setLike: React.Dispatch<React.SetStateAction<number>>;
 }
 
-const LikeButton = ({ isProject, userId, projectId, setLike }: IProps) => {
+const LikeButton = ({
+  isProject,
+  userId,
+  projectId,
+  recieveduserId,
+  setLike,
+}: IProps) => {
   const [isLike, setIsLike] = useState(false);
   let formData = {};
   if (isProject) {
@@ -36,8 +43,13 @@ const LikeButton = ({ isProject, userId, projectId, setLike }: IProps) => {
       projectId,
       userId,
     };
+  } else {
+    formData = {
+      recieveduserId,
+      userId,
+    };
   }
-
+  console.log(formData);
   const handleUplike = async () => {
     try {
       const {
@@ -68,6 +80,10 @@ const LikeButton = ({ isProject, userId, projectId, setLike }: IProps) => {
 
   const onHeartClick = (event: React.MouseEvent<HTMLElement>) => {
     event.preventDefault();
+    if (!userId) {
+      alert('로그인 후 사용 가능합니다.');
+      return;
+    }
 
     if (!isLike) {
       handleUplike();
@@ -82,7 +98,6 @@ const LikeButton = ({ isProject, userId, projectId, setLike }: IProps) => {
         const {
           data: { likes },
         } = await axios.post(`${LIKE_SERVER}/getLike`, formData);
-        setLike(likes.length);
         likes.forEach((like: any) => {
           if (like.SenduserId === userId) {
             setIsLike(true);

--- a/client/src/Components/People/PeopleListItem.tsx
+++ b/client/src/Components/People/PeopleListItem.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import { PosData, LevelData } from '../Common/OptionData';
 import fullHeart from '../../img/full-heart.svg';
 import emptyHeart from '../../img/empty-heart.svg';
 import borderHeart from '../../img/border-heart.svg';
+import LikeButton from '../Common/LikeButton';
 
 const User = styled.div`
   width: 100%;
@@ -103,22 +104,18 @@ const UserStack = styled.span`
   line-height: 1.4em;
 `;
 
-const LikeButton = styled.span`
+const SLikeButton = styled(LikeButton)`
   width: 18px;
   height: 18px;
-  position: absolute;
-  background-image: url(${emptyHeart});
-  background-repeat: no-repeat;
-  background-size: contain;
-  cursor: pointer;
-  &:hover {
-    background-image: url(${borderHeart});
-  }
+  top: 0;
+  right: 0;
 `;
 
-const Like = styled.span`
-  margin-left: 25px;
+const LikeIcon = styled.span`
+  font-size: 1.5em;
 `;
+
+const Like = styled.span``;
 
 interface IUser {
   avartarImg: string;
@@ -137,16 +134,20 @@ const PeopleListItem = ({
   interestSkills,
   receivedLike,
 }: IUser) => {
+  const [like, setLike] = useState(receivedLike);
+
   const PosText = PosData.find((item) => {
     if (item.value === position) {
       return item;
     }
   });
+
   const LevelText = LevelData.find((item) => {
     if (item.value === positionLevel) {
       return item;
     }
   });
+
   return (
     <User>
       <UserTop>
@@ -176,8 +177,15 @@ const PeopleListItem = ({
             <UserStack key={index}>{stack}</UserStack>
           ))}
         </UserStackList>
-        <LikeButton />
-        <Like>{receivedLike ? receivedLike : 0}</Like>
+        <SLikeButton
+          isProject={false}
+          userId={localStorage.getItem('userId')}
+          projectId={null}
+          recieveduserId={nickname}
+          setLike={setLike}
+        />
+        <LikeIcon>❤ </LikeIcon>
+        <Like>{like ? like : 0}</Like>
       </UserBottom>
     </User>
   );

--- a/client/src/Components/People/PeopleListItem.tsx
+++ b/client/src/Components/People/PeopleListItem.tsx
@@ -116,7 +116,9 @@ const LikeButton = styled.span`
   }
 `;
 
-const Like = styled.span``;
+const Like = styled.span`
+  margin-left: 25px;
+`;
 
 interface IUser {
   avartarImg: string;
@@ -175,7 +177,7 @@ const PeopleListItem = ({
           ))}
         </UserStackList>
         <LikeButton />
-        <Like>{receivedLike}</Like>
+        <Like>{receivedLike ? receivedLike : 0}</Like>
       </UserBottom>
     </User>
   );

--- a/client/src/Components/People/PeopleListItem.tsx
+++ b/client/src/Components/People/PeopleListItem.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import { PosData, LevelData } from '../Common/OptionData';
+import fullHeart from '../../img/full-heart.svg';
+import emptyHeart from '../../img/empty-heart.svg';
+import borderHeart from '../../img/border-heart.svg';
 
 const User = styled.div`
   width: 100%;
@@ -100,6 +103,19 @@ const UserStack = styled.span`
   line-height: 1.4em;
 `;
 
+const LikeButton = styled.span`
+  width: 18px;
+  height: 18px;
+  position: absolute;
+  background-image: url(${emptyHeart});
+  background-repeat: no-repeat;
+  background-size: contain;
+  cursor: pointer;
+  &:hover {
+    background-image: url(${borderHeart});
+  }
+`;
+
 const Like = styled.span``;
 
 interface IUser {
@@ -158,7 +174,8 @@ const PeopleListItem = ({
             <UserStack key={index}>{stack}</UserStack>
           ))}
         </UserStackList>
-        <Like>♥ {receivedLike}</Like>
+        <LikeButton />
+        <Like>{receivedLike}</Like>
       </UserBottom>
     </User>
   );

--- a/client/src/Components/People/PeopleListItem.tsx
+++ b/client/src/Components/People/PeopleListItem.tsx
@@ -180,8 +180,7 @@ const PeopleListItem = ({
         <SLikeButton
           isProject={false}
           userId={localStorage.getItem('userId')}
-          projectId={null}
-          recieveduserId={nickname}
+          targetId={nickname}
           setLike={setLike}
         />
         <LikeIcon>❤ </LikeIcon>

--- a/client/src/Components/Project/LikeButton.tsx
+++ b/client/src/Components/Project/LikeButton.tsx
@@ -1,0 +1,97 @@
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import fullHeart from '../../img/full-heart.svg';
+import emptyHeart from '../../img/empty-heart.svg';
+import borderHeart from '../../img/border-heart.svg';
+import axios from 'axios';
+import { LIKE_SERVER } from '../../Config';
+
+const HeartBtn = styled.div<{ isLike: boolean }>`
+  width: 24px;
+  height: 24px;
+  position: absolute;
+  top: 15px;
+  right: 20px;
+  background-image: url(${(props) => (props.isLike ? fullHeart : emptyHeart)});
+  background-repeat: no-repeat;
+  background-size: contain;
+  cursor: pointer;
+  &:hover {
+    background-image: url(${borderHeart});
+  }
+`;
+
+interface IProps {
+  isProject: boolean;
+  userId: null | string;
+  projectId: null | string;
+}
+
+const LikeButton = ({ isProject, userId, projectId }: IProps) => {
+  const [isLike, setIsLike] = useState(false);
+  let formData = {};
+  if (isProject) {
+    formData = {
+      projectId,
+      userId,
+    };
+  }
+
+  const handleUplike = async () => {
+    try {
+      const {
+        data: { success },
+      } = await axios.post(`${LIKE_SERVER}/upLike`, formData);
+      if (success) {
+        setIsLike(true);
+      }
+    } catch (error) {
+      alert(`좋아요에 실패했습니다. ${error}`);
+    }
+  };
+
+  const handleUnLike = async () => {
+    try {
+      const {
+        data: { success },
+      } = await axios.post(`${LIKE_SERVER}/unLike`, formData);
+      if (success) {
+        setIsLike(false);
+      }
+    } catch (error) {
+      alert(`좋아요 취소에 실패했습니다. ${error}`);
+    }
+  };
+
+  const onHeartClick = (event: React.MouseEvent<HTMLElement>) => {
+    event.preventDefault();
+
+    if (!isLike) {
+      handleUplike();
+    } else {
+      handleUnLike();
+    }
+  };
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const {
+          data: { likes },
+        } = await axios.post(`${LIKE_SERVER}/getLike`, formData);
+        likes.forEach((like: any) => {
+          if (like.SenduserId === userId) {
+            setIsLike(true);
+          }
+        });
+      } catch (error) {
+        alert(`좋아요 정보를 받아오지 못했습니다. ${error}`);
+      }
+    };
+    fetchData();
+  }, []);
+
+  return <HeartBtn onClick={onHeartClick} isLike={isLike} />;
+};
+
+export default LikeButton;

--- a/client/src/Components/Project/LikeButton.tsx
+++ b/client/src/Components/Project/LikeButton.tsx
@@ -25,9 +25,10 @@ interface IProps {
   isProject: boolean;
   userId: null | string;
   projectId: null | string;
+  setLike: React.Dispatch<React.SetStateAction<number>>;
 }
 
-const LikeButton = ({ isProject, userId, projectId }: IProps) => {
+const LikeButton = ({ isProject, userId, projectId, setLike }: IProps) => {
   const [isLike, setIsLike] = useState(false);
   let formData = {};
   if (isProject) {
@@ -44,6 +45,7 @@ const LikeButton = ({ isProject, userId, projectId }: IProps) => {
       } = await axios.post(`${LIKE_SERVER}/upLike`, formData);
       if (success) {
         setIsLike(true);
+        setLike((like) => like + 1);
       }
     } catch (error) {
       alert(`좋아요에 실패했습니다. ${error}`);
@@ -57,6 +59,7 @@ const LikeButton = ({ isProject, userId, projectId }: IProps) => {
       } = await axios.post(`${LIKE_SERVER}/unLike`, formData);
       if (success) {
         setIsLike(false);
+        setLike((like) => like - 1);
       }
     } catch (error) {
       alert(`좋아요 취소에 실패했습니다. ${error}`);
@@ -79,6 +82,7 @@ const LikeButton = ({ isProject, userId, projectId }: IProps) => {
         const {
           data: { likes },
         } = await axios.post(`${LIKE_SERVER}/getLike`, formData);
+        setLike(likes.length);
         likes.forEach((like: any) => {
           if (like.SenduserId === userId) {
             setIsLike(true);

--- a/client/src/Components/Project/ProjectBox.tsx
+++ b/client/src/Components/Project/ProjectBox.tsx
@@ -158,7 +158,7 @@ const ProjectBox = ({
   receivedLike,
 }: IProjectProps) => {
   const [like, setLike] = useState(receivedLike);
-  console.log(receivedLike);
+
   const fieldLabel = FieldData.find((item) => {
     if (item.value === category) {
       return item;

--- a/client/src/Components/Project/ProjectBox.tsx
+++ b/client/src/Components/Project/ProjectBox.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import basicHeart from '../../img/basic-heart.svg';
 import { Link } from 'react-router-dom';
 import { FieldData } from '../Common/OptionData';
-import LikeButton from './LikeButton';
+import LikeButton from '../Common/LikeButton';
 
 const ProjectTitle = styled.div`
   display: flex;
@@ -176,6 +176,7 @@ const ProjectBox = ({
             isProject={true}
             userId={localStorage.getItem('userId')}
             projectId={id}
+            recieveduserId={null}
             setLike={setLike}
           />
           <ProjectInfo>

--- a/client/src/Components/Project/ProjectBox.tsx
+++ b/client/src/Components/Project/ProjectBox.tsx
@@ -1,8 +1,5 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import fullHeart from '../../img/full-heart.svg';
-import emptyHeart from '../../img/empty-heart.svg';
-import borderHeart from '../../img/border-heart.svg';
 import basicHeart from '../../img/basic-heart.svg';
 import { Link } from 'react-router-dom';
 import { FieldData } from '../Common/OptionData';
@@ -72,22 +69,6 @@ const RecruitmentStatus = styled.div`
   top: 15px;
   left: 20px;
 `;
-
-const HeartBtn = styled.div`
-  width: 24px;
-  height: 24px;
-  position: absolute;
-  top: 15px;
-  right: 20px;
-  background-image: url(${emptyHeart});
-  background-repeat: no-repeat;
-  background-size: contain;
-  cursor: pointer;
-  &:hover {
-    background-image: url(${borderHeart});
-  }
-`;
-
 const ProjectInfo = styled.div`
   display: flex;
   flex-wrap: nowrap;
@@ -175,6 +156,8 @@ const ProjectBox = ({
   category,
   receivedLike,
 }: IProjectProps) => {
+  const [like, setLike] = useState(0);
+
   const fieldLabel = FieldData.find((item) => {
     if (item.value === category) {
       return item;
@@ -193,6 +176,7 @@ const ProjectBox = ({
             isProject={true}
             userId={localStorage.getItem('userId')}
             projectId={id}
+            setLike={setLike}
           />
           <ProjectInfo>
             <Recruitment>
@@ -205,7 +189,7 @@ const ProjectBox = ({
             </Description>
             <FavoriteNumber>
               <HeartIcon />
-              <FavoriteCount>{receivedLike}</FavoriteCount>
+              <FavoriteCount>{like}</FavoriteCount>
             </FavoriteNumber>
           </ProjectInfo>
         </ProjectThumb>

--- a/client/src/Components/Project/ProjectBox.tsx
+++ b/client/src/Components/Project/ProjectBox.tsx
@@ -69,6 +69,7 @@ const RecruitmentStatus = styled.div`
   top: 15px;
   left: 20px;
 `;
+
 const ProjectInfo = styled.div`
   display: flex;
   flex-wrap: nowrap;
@@ -156,8 +157,8 @@ const ProjectBox = ({
   category,
   receivedLike,
 }: IProjectProps) => {
-  const [like, setLike] = useState(0);
-
+  const [like, setLike] = useState(receivedLike);
+  console.log(receivedLike);
   const fieldLabel = FieldData.find((item) => {
     if (item.value === category) {
       return item;

--- a/client/src/Components/Project/ProjectBox.tsx
+++ b/client/src/Components/Project/ProjectBox.tsx
@@ -180,6 +180,10 @@ const ProjectBox = ({
     }
   });
 
+  const onHeartClick = (event: React.MouseEvent<HTMLElement>) => {
+    event.preventDefault();
+  };
+
   return (
     <Link to={`/project/${id}`}>
       <ProjectContent>
@@ -188,7 +192,7 @@ const ProjectBox = ({
           <RecruitmentStatus>
             {state[0] >= state[1] ? '모집완료' : '모집중'}
           </RecruitmentStatus>
-          <HeartBtn />
+          <HeartBtn onClick={onHeartClick} />
           <ProjectInfo>
             <Recruitment>
               모집인원: {state[0]}/{state[1]}

--- a/client/src/Components/Project/ProjectBox.tsx
+++ b/client/src/Components/Project/ProjectBox.tsx
@@ -6,6 +6,7 @@ import borderHeart from '../../img/border-heart.svg';
 import basicHeart from '../../img/basic-heart.svg';
 import { Link } from 'react-router-dom';
 import { FieldData } from '../Common/OptionData';
+import LikeButton from './LikeButton';
 
 const ProjectTitle = styled.div`
   display: flex;
@@ -180,10 +181,6 @@ const ProjectBox = ({
     }
   });
 
-  const onHeartClick = (event: React.MouseEvent<HTMLElement>) => {
-    event.preventDefault();
-  };
-
   return (
     <Link to={`/project/${id}`}>
       <ProjectContent>
@@ -192,7 +189,11 @@ const ProjectBox = ({
           <RecruitmentStatus>
             {state[0] >= state[1] ? '모집완료' : '모집중'}
           </RecruitmentStatus>
-          <HeartBtn onClick={onHeartClick} />
+          <LikeButton
+            isProject={true}
+            userId={localStorage.getItem('userId')}
+            projectId={id}
+          />
           <ProjectInfo>
             <Recruitment>
               모집인원: {state[0]}/{state[1]}

--- a/client/src/Components/Project/ProjectBox.tsx
+++ b/client/src/Components/Project/ProjectBox.tsx
@@ -176,8 +176,7 @@ const ProjectBox = ({
           <LikeButton
             isProject={true}
             userId={localStorage.getItem('userId')}
-            projectId={id}
-            recieveduserId={null}
+            targetId={id}
             setLike={setLike}
           />
           <ProjectInfo>

--- a/client/src/Components/Project/ProjectBoxList.tsx
+++ b/client/src/Components/Project/ProjectBoxList.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 
 const ProjectBoxGrid = styled.li`
   display: grid;
+  grid-column-gap: 30px;
   grid-row-gap: 45px;
   grid-template-columns: repeat(3, 1fr);
   @media screen and (max-width: 750px) {

--- a/client/src/Pages/Home/Home.tsx
+++ b/client/src/Pages/Home/Home.tsx
@@ -97,7 +97,7 @@ const Home = () => {
                       getRequiredMembers(project.position),
                     ]}
                     category={project.field}
-                    receivedLike={0}
+                    receivedLike={project.receivedLike}
                   />
                 ))
               : '신규 프로젝트가 없습니다.'}
@@ -122,7 +122,7 @@ const Home = () => {
                       getRequiredMembers(project.position),
                     ]}
                     category={project.field}
-                    receivedLike={0}
+                    receivedLike={project.receivedLike}
                   />
                 ))
               : '모집중인 프로젝트가 없습니다.'}

--- a/client/src/Pages/People/PeoplePresenter.tsx
+++ b/client/src/Pages/People/PeoplePresenter.tsx
@@ -58,6 +58,7 @@ const PeoplePresenter = () => {
             position: userInfo.position,
             positionLevel: userInfo.positionLevel,
             interestSkills: userInfo.interestSkills,
+            receivedLike: userInfo.receivedLike,
           };
         });
         if (!filterChange) setUsers([...users, ...user]);

--- a/server/models/Like.interface.ts
+++ b/server/models/Like.interface.ts
@@ -1,7 +1,7 @@
 import { Date, Document, Schema } from 'mongoose';
 
 export interface ILike extends Document {
-  RecieveduserId: Schema.Types.ObjectId;
+  RecieveduserId?: Schema.Types.ObjectId;
   SenduserId: Schema.Types.ObjectId;
-  ProjectId: Schema.Types.ObjectId;
+  ProjectId?: Schema.Types.ObjectId;
 }

--- a/server/models/Like.interface.ts
+++ b/server/models/Like.interface.ts
@@ -1,7 +1,7 @@
 import { Date, Document, Schema } from 'mongoose';
 
 export interface ILike extends Document {
-  RecieveduserId?: Schema.Types.ObjectId;
-  SenduserId: Schema.Types.ObjectId;
-  ProjectId?: Schema.Types.ObjectId;
+  RecieveduserId?: string;
+  SenduserId: string;
+  ProjectId?: string;
 }

--- a/server/models/Like.ts
+++ b/server/models/Like.ts
@@ -1,21 +1,21 @@
 import mongoose, { Schema, Model } from 'mongoose';
-import {ILike} from './Like.interface';
+import { ILike } from './Like.interface';
 
 const LikeSchema: mongoose.Schema<ILike> = new Schema(
   {
     RecieveduserId: {
-        type: Schema.Types.ObjectId,
-        ref: 'User'
+      type: String,
+      ref: 'User',
     },
     SenduserId: {
-        type: Schema.Types.ObjectId,
-        ref: 'User'
+      type: Schema.Types.ObjectId,
+      ref: 'User',
     },
     ProjectId: {
-        type: Schema.Types.ObjectId,
-        ref: 'Project'
-    }
-},
+      type: Schema.Types.ObjectId,
+      ref: 'Project',
+    },
+  },
   {
     timestamps: true,
   }

--- a/server/routes/Like.ts
+++ b/server/routes/Like.ts
@@ -1,9 +1,79 @@
-import express, { Request, Response } from "express";
+import express, { Request, Response } from 'express';
+import Like from '../models/Like';
+import { ILike } from '../models/Like.interface';
 
 const router = express.Router();
 
-router.get("/",(req: Request, res: Response) => {
-  
+router.post('/getLike', (req: Request, res: Response) => {
+  let data = {};
+
+  if (req.body.projectId) {
+    data = { ProjectId: req.body.projectId };
+  } else {
+    data = { RecieveduserId: req.body.RecieveduserId };
+  }
+
+  Like.find(data).exec((error, likes) => {
+    if (error) {
+      return res.status(400).send(error);
+    }
+    res.status(200).json({
+      success: true,
+      likes,
+    });
+  });
 });
 
-module.exports =router;
+router.post('/upLike', (req: Request, res: Response) => {
+  let data = {};
+
+  if (req.body.projectId) {
+    data = {
+      ProjectId: req.body.projectId,
+      SenduserId: req.body.userId,
+    };
+  } else {
+    data = {
+      RecieveduserId: req.body.RecieveduserId,
+      SenduserId: req.body.userId,
+    };
+  }
+
+  const like = new Like(data);
+
+  like.save((error, result) => {
+    if (error) {
+      return res.status(400).send(error);
+    }
+    return res.status(200).json({
+      success: true,
+    });
+  });
+});
+
+router.post('/unLike', (req: Request, res: Response) => {
+  let data = {};
+
+  if (req.body.projectId) {
+    data = {
+      ProjectId: req.body.projectId,
+      SenduserId: req.body.userId,
+    };
+  } else {
+    data = {
+      RecieveduserId: req.body.RecieveduserId,
+      SenduserId: req.body.userId,
+    };
+  }
+
+  Like.findOneAndDelete(data).exec((error, result) => {
+    if (error) {
+      return res.status(400).send(error);
+    }
+    res.status(200).json({
+      success: true,
+    });
+  });
+});
+
+module.exports = router;

--- a/server/routes/Like.ts
+++ b/server/routes/Like.ts
@@ -1,5 +1,9 @@
 import express, { Request, Response } from 'express';
 import Like from '../models/Like';
+import { Project } from '../models/Project';
+import { IProject } from '../models/Project.interface';
+import { User } from '../models/User';
+import { IUser } from '../models/User.interface';
 import { ILike } from '../models/Like.interface';
 
 const router = express.Router();
@@ -10,7 +14,7 @@ router.post('/getLike', (req: Request, res: Response) => {
   if (req.body.projectId) {
     data = { ProjectId: req.body.projectId };
   } else {
-    data = { RecieveduserId: req.body.RecieveduserId };
+    data = { RecieveduserId: req.body.recieveduserId };
   }
 
   Like.find(data).exec((error, likes) => {
@@ -34,7 +38,7 @@ router.post('/upLike', (req: Request, res: Response) => {
     };
   } else {
     data = {
-      RecieveduserId: req.body.RecieveduserId,
+      RecieveduserId: req.body.recieveduserId,
       SenduserId: req.body.userId,
     };
   }
@@ -45,9 +49,32 @@ router.post('/upLike', (req: Request, res: Response) => {
     if (error) {
       return res.status(400).send(error);
     }
-    res.status(200).json({
-      success: true,
-    });
+
+    if (req.body.projectId) {
+      Project.findOneAndUpdate(
+        { _id: req.body.projectId },
+        { $inc: { receivedLike: 1 } }
+      ).exec((error, result) => {
+        if (error) {
+          return res.status(400).send(error);
+        }
+        return res.status(200).json({
+          success: true,
+        });
+      });
+    } else {
+      User.findOneAndUpdate(
+        { nickname: req.body.recieveduserId },
+        { $inc: { receivedLike: 1 } }
+      ).exec((error, result) => {
+        if (error) {
+          return res.status(400).send(error);
+        }
+        return res.status(200).json({
+          success: true,
+        });
+      });
+    }
   });
 });
 
@@ -61,7 +88,7 @@ router.post('/unLike', (req: Request, res: Response) => {
     };
   } else {
     data = {
-      RecieveduserId: req.body.RecieveduserId,
+      RecieveduserId: req.body.recieveduserId,
       SenduserId: req.body.userId,
     };
   }
@@ -70,9 +97,31 @@ router.post('/unLike', (req: Request, res: Response) => {
     if (error) {
       return res.status(400).send(error);
     }
-    res.status(200).json({
-      success: true,
-    });
+    if (req.body.projectId) {
+      Project.findOneAndUpdate(
+        { _id: req.body.projectId },
+        { $inc: { receivedLike: -1 } }
+      ).exec((error, result) => {
+        if (error) {
+          return res.status(400).send(error);
+        }
+        return res.status(200).json({
+          success: true,
+        });
+      });
+    } else {
+      User.findOneAndUpdate(
+        { nickname: req.body.recieveduserId },
+        { $inc: { receivedLike: -1 } }
+      ).exec((error, result) => {
+        if (error) {
+          return res.status(400).send(error);
+        }
+        return res.status(200).json({
+          success: true,
+        });
+      });
+    }
   });
 });
 

--- a/server/routes/Like.ts
+++ b/server/routes/Like.ts
@@ -45,7 +45,7 @@ router.post('/upLike', (req: Request, res: Response) => {
     if (error) {
       return res.status(400).send(error);
     }
-    return res.status(200).json({
+    res.status(200).json({
       success: true,
     });
   });


### PR DESCRIPTION
## 개요

- 유저 & 프로젝트 좋아요 기능 추가
 
## 작업 내용

- Like router, schema 추가
- LikeButton 컴포넌트 생성 후 재사용
- 하트 클릭 시 project, user DB의 receivedLike 증감
- 하트 클릭 시 좋아요 +1 하트 변경
- 이미 좋아요 한 하트 클릭 시 좋아요 -1
- 리로드 시 좋아요 했던 프로젝트, 사람 하트 표시 

## 스크린샷
- project
![image](https://user-images.githubusercontent.com/64254228/122374164-1b506200-cf9d-11eb-8906-b18ad978500c.png)

- user
![image](https://user-images.githubusercontent.com/64254228/122374240-2a371480-cf9d-11eb-910d-acb1eb81ee89.png)


------------------------------------
bug:
Home page 에서 동일한 프로젝트나 유저가 있을 때 (ex. Home에서 1번 프로젝트가 신규,모집중 둘 다 표시될 때)
좋아요 클릭할 시 동일하게 반영 안되고 새로고침 해야 반영됨

Resolve #125