### PR TITLE
프로젝트 상세 페이지 기능 구현

### DIFF
--- a/client/src/Components/Project/ProjectDetail/Comment.tsx
+++ b/client/src/Components/Project/ProjectDetail/Comment.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import Button from '../../Common/Button';
 
 const Container = styled.div`
   margin-bottom: 5px;
@@ -65,23 +66,49 @@ const Text = styled.textarea`
   font-family: 'Noto Sans KR', sans-serif;
 `;
 
-const Comment = () => {
+interface IProps {
+  avartarImg: string | undefined;
+  nickname: string;
+  time: Date;
+  content: string;
+  remove: React.MouseEventHandler<HTMLButtonElement> | undefined;
+}
+
+const Comment = ({ avartarImg, nickname, time, content, remove }: IProps) => {
   return (
     <Container>
       <ContentsWrap>
         <Top>
           <UserInfo>
             <ImageWrap>
-              <Image src="https://phinf.pstatic.net/contact/20200810_233/1597002626521vhHs0_JPEG/%C8%BF_%BF%F8%BA%BB.jpg" />
+              <Image
+                src={
+                  avartarImg
+                    ? avartarImg
+                    : 'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_960_720.png'
+                }
+                alt="userImg"
+              />
             </ImageWrap>
-            <Name>용현준</Name>
+            <Name>{nickname}</Name>
           </UserInfo>
-          <Time>21.03.30 13:16</Time>
+          <Time>
+            {`${time.getFullYear()}.${
+              time.getMonth() + 1
+            }.${time.getDate()} / ${time.getHours()}:${time.getMinutes()}`}
+            {remove && (
+              <Button
+                ButtonColor="red"
+                ButtonMode="active"
+                ButtonName="삭제"
+                ButtonSize="small"
+                onClick={remove}
+              />
+            )}
+          </Time>
         </Top>
         <CommentContentWrap>
-          <Text disabled rows={2} maxLength={1000}>
-            안녕하세요
-          </Text>
+          <Text disabled rows={2} maxLength={1000} value={content} />
         </CommentContentWrap>
       </ContentsWrap>
     </Container>

--- a/client/src/Components/Project/ProjectDetail/Info.tsx
+++ b/client/src/Components/Project/ProjectDetail/Info.tsx
@@ -1,9 +1,12 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import Status from './Status';
 import Reference from './Reference';
 import { Link } from 'react-router-dom';
 import theme from '../../../theme';
+import PeopleListItem from '../../People/PeopleListItem';
+import axios from 'axios';
+import { PROJECT_SERVER } from '../../../Config';
 
 const Container = styled.div``;
 
@@ -20,6 +23,7 @@ const TabTitle = styled.h3`
 
 const P = styled.p`
   line-height: 1.5;
+  margin-top: 1rem;
 `;
 
 const TabText = styled.p`
@@ -37,13 +41,54 @@ interface IProps {
   referenceURL: string[];
   nickname: string;
   position: Ipos[];
+  projectId: string;
+  uPos: string;
+  uPosLv: string;
+  uInterestSkills: string[];
+  uReceivedLike: number;
+  avartarImg: string;
 }
 
-const Info = ({ info, referenceURL, nickname, position }: IProps) => {
+interface IUser extends Document {
+  item: {
+    _id: string;
+    avartarImg: string;
+    nickname: string;
+    email: string;
+    position: string;
+    positionLevel: string;
+    interestSkills: string[];
+    receivedLike: number;
+  };
+}
+
+const Info = ({
+  info,
+  referenceURL,
+  nickname,
+  position,
+  projectId,
+  uPos,
+  uPosLv,
+  uInterestSkills,
+  uReceivedLike,
+  avartarImg,
+}: IProps) => {
+  const [memberList, setMemberList] = useState<IUser[]>([]);
+  useEffect(() => {
+    axios.get(`${PROJECT_SERVER}/memberList/${projectId}`).then((res) => {
+      if (!res.data.success) {
+        alert(`현재 멤버 정보를 가져오는 데 실패했습니다 (${res.data.err})`);
+        return;
+      }
+      setMemberList(res.data.result);
+    });
+  }, [memberList]);
+
   return (
     <Container>
       <Section>
-        <Status position={position} />
+        <Status position={position} projectId={projectId} />
       </Section>
       <Section>
         <TabTitle>- 소개</TabTitle>
@@ -59,13 +104,32 @@ const Info = ({ info, referenceURL, nickname, position }: IProps) => {
       </Section>
       <Section>
         <TabTitle>리더</TabTitle>
-        <Link to={`/people/${nickname}`} style={{ color: theme.palette.jade }}>
-          {nickname}
-        </Link>
+        <PeopleListItem
+          avartarImg={avartarImg}
+          interestSkills={uInterestSkills}
+          nickname={nickname}
+          position={uPos}
+          positionLevel={uPosLv}
+          receivedLike={uReceivedLike}
+        />
       </Section>
       <Section>
         <TabTitle>멤버</TabTitle>
-        214214
+        {memberList.length ? (
+          memberList.map((user) => (
+            <PeopleListItem
+              key={user.item._id}
+              avartarImg={user.item.avartarImg}
+              interestSkills={user.item.interestSkills}
+              nickname={user.item.nickname}
+              position={user.item.position}
+              positionLevel={user.item.positionLevel}
+              receivedLike={user.item.receivedLike}
+            />
+          ))
+        ) : (
+          <P>참가한 멤버가 없습니다</P>
+        )}
       </Section>
     </Container>
   );

--- a/client/src/Components/Project/ProjectDetail/Info.tsx
+++ b/client/src/Components/Project/ProjectDetail/Info.tsx
@@ -85,6 +85,10 @@ const Info = ({
     });
   }, [memberList]);
 
+  useEffect(() => {
+    return () => setMemberList([]);
+  }, []);
+
   return (
     <Container>
       <Section>

--- a/client/src/Components/Project/ProjectDetail/Management.tsx
+++ b/client/src/Components/Project/ProjectDetail/Management.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import UserInfo from './UserInfo';
 import Button from '../../../Components/Common/Button';
 import { Link, useHistory } from 'react-router-dom';
 import axios from 'axios';
-import { MANAGE_SERVER } from '../../../Config';
+import { MANAGE_SERVER, PROJECT_SERVER } from '../../../Config';
+import { LevelTransfer } from '../../../Components/Common/transformValue';
 
 const Container = styled.div``;
 const Section = styled.section`
@@ -23,12 +24,32 @@ const BtnBox = styled.div`
   align-items: center;
 `;
 
+const P = styled.p`
+  margin-top: 2rem;
+`;
+
 interface IProps {
   projectId: string;
 }
 
+interface IUser extends Document {
+  item: {
+    _id: string;
+    avartarImg: string;
+    nickname: string;
+    email: string;
+    position: string;
+    positionLevel: string;
+    interestSkills: string[];
+    receivedLike: number;
+  };
+  msg?: string;
+}
+
 function Management({ projectId }: IProps) {
   const history = useHistory();
+  const [joinList, setJoinList] = useState<IUser[]>([]);
+  const [memberList, setMemberList] = useState<IUser[]>([]);
   const handleDelete: React.MouseEventHandler<HTMLButtonElement> = (e) => {
     axios
       .post(`${MANAGE_SERVER}/deleteProject`, { pid: projectId })
@@ -42,45 +63,105 @@ function Management({ projectId }: IProps) {
       });
   };
 
+  const reject = (id: string) => {
+    axios
+      .post(`${MANAGE_SERVER}/reject`, { pid: projectId, uid: id })
+      .then((res) => {
+        if (!res.data.success) {
+          alert(`지원자 삭제를 실패했습니다 (${res.data.err})`);
+          return;
+        }
+        alert('지원자 삭제 완료');
+        setJoinList([]);
+      });
+  };
+  const accept = (id: string, pos: string) => {
+    axios
+      .post(`${MANAGE_SERVER}/accept`, { pid: projectId, uid: id, pos: pos })
+      .then((res) => {
+        if (!res.data.success) {
+          alert(`지원 승인을 실패했습니다 (${res.data.err})`);
+          return;
+        }
+        alert('지원 승인 완료');
+        setJoinList([]);
+        setMemberList([]);
+      });
+  };
+
+  const remove = (id: string, pos: string) => {
+    axios
+      .post(`${MANAGE_SERVER}/remove`, { pid: projectId, uid: id, pos: pos })
+      .then((res) => {
+        if (!res.data.success) {
+          alert(`멤버 삭제를 실패했습니다 (${res.data.err})`);
+          return;
+        }
+        alert('멤버 삭제 완료');
+        setMemberList([]);
+      });
+  };
+
+  useEffect(() => {
+    axios.get(`${PROJECT_SERVER}/joinList/${projectId}`).then((res) => {
+      if (!res.data.success) {
+        alert(`지원 현황 정보를 가져오는 데 실패했습니다 (${res.data.err})`);
+        return;
+      }
+      setJoinList(res.data.result);
+    });
+  }, [joinList]);
+
+  useEffect(() => {
+    axios.get(`${PROJECT_SERVER}/memberList/${projectId}`).then((res) => {
+      if (!res.data.success) {
+        alert(`현재 멤버 정보를 가져오는 데 실패했습니다 (${res.data.err})`);
+        return;
+      }
+      setMemberList(res.data.result);
+    });
+  }, [memberList]);
+
   return (
     <Container>
       <Section>
         <Title>지원현황</Title>
-        <UserInfo
-          avatarImg="http://kawala.in/assets/global/images/avatars/avatar1.png"
-          isAdd={true}
-          isRemove={true}
-          nickName="User1"
-          pos="백엔드"
-          posLv="초보"
-          reason="안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요"
-        />
-        <UserInfo
-          avatarImg="http://kawala.in/assets/global/images/avatars/avatar2.png"
-          isAdd={true}
-          isRemove={true}
-          nickName="User2"
-          pos="IOS"
-          posLv="초보"
-          reason="열심히 할게요"
-        />
+        {joinList.length ? (
+          joinList.map((user) => (
+            <UserInfo
+              avatarImg={user.item.avartarImg}
+              isAdd={true}
+              isRemove={true}
+              nickName={user.item.nickname}
+              pos={user.item.position}
+              posLv={LevelTransfer(user.item.positionLevel)}
+              reason={user.msg ? user.msg : '작성한 내용이 없습니다.'}
+              key={user.item._id}
+              addHandler={() => accept(user.item._id, user.item.position)}
+              removeHandler={() => reject(user.item._id)}
+            />
+          ))
+        ) : (
+          <P>지원자가 없습니다</P>
+        )}
       </Section>
       <Section>
         <Title>현재멤버</Title>
-        <UserInfo
-          avatarImg="http://kawala.in/assets/global/images/avatars/avatar3.png"
-          isAdd={false}
-          isRemove={true}
-          nickName="User3"
-          pos="안드로이드"
-        />
-        <UserInfo
-          avatarImg="http://kawala.in/assets/global/images/avatars/avatar4.png"
-          isAdd={false}
-          isRemove={true}
-          nickName="User4"
-          pos="웹프론트엔드"
-        />
+        {memberList.length ? (
+          memberList.map((user) => (
+            <UserInfo
+              avatarImg={user.item.avartarImg}
+              isAdd={false}
+              isRemove={true}
+              nickName={user.item.nickname}
+              pos={user.item.position}
+              key={user.item._id}
+              removeHandler={() => remove(user.item._id, user.item.position)}
+            />
+          ))
+        ) : (
+          <P>현재 참가한 멤버가 없습니다</P>
+        )}
       </Section>
       <Section>
         <BtnBox>

--- a/client/src/Components/Project/ProjectDetail/Management.tsx
+++ b/client/src/Components/Project/ProjectDetail/Management.tsx
@@ -122,6 +122,13 @@ function Management({ projectId }: IProps) {
     });
   }, [memberList]);
 
+  useEffect(() => {
+    return () => {
+      setJoinList([]);
+      setMemberList([]);
+    };
+  }, []);
+
   return (
     <Container>
       <Section>

--- a/client/src/Components/Project/ProjectDetail/Question.tsx
+++ b/client/src/Components/Project/ProjectDetail/Question.tsx
@@ -1,8 +1,10 @@
 import { PromiseProvider } from 'mongoose';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import Comment from './Comment';
 import Button from '../../Common/Button';
+import axios from 'axios';
+import { COMMENT_SERVER, USER_SERVER } from '../../../Config';
 
 const Container = styled.div``;
 
@@ -55,19 +57,126 @@ const ButtonWrapper = styled.div`
   margin-left: 60px;
 `;
 
-const Question = () => {
+const P = styled.p`
+  margin-top: 1.5rem;
+`;
+
+interface IProps {
+  projectId: string;
+}
+
+interface IComment {
+  nickname: string;
+  avartarImg: string | undefined;
+  createdAt: Date;
+  content: string;
+}
+
+const Question = ({ projectId }: IProps) => {
+  const userId = localStorage.getItem('userId');
+  const [comments, setComments] = useState<IComment[]>([]);
+  const [msg, setMsg] = useState('');
+  const [avartarImg, setAvartarImg] = useState(
+    'https://letspl.me/assets/images/prof_noImg.svg'
+  );
+  const [nickname, setNickname] = useState('');
+
+  const handleChange: React.ChangeEventHandler<HTMLTextAreaElement> = (e) => {
+    setMsg(e.target.value);
+  };
+  const handleRemove = (
+    writer: string | null,
+    projectId: string,
+    content: string,
+    createdAt: Date
+  ) => {
+    axios
+      .post(`${COMMENT_SERVER}/remove`, {
+        writer: writer,
+        projectId: projectId,
+        content: content,
+        createdAt: createdAt,
+      })
+      .then((res) => {
+        if (!res.data.success) {
+          alert(`메세지 삭제를 실패했습니다 (${res.data.err})`);
+          return;
+        }
+        axios.get(`${COMMENT_SERVER}/${projectId}`).then((res) => {
+          if (!res.data.success) {
+            alert(`Comment 정보를 가져오는 데 실패했습니다 (${res.data.err})`);
+            return;
+          }
+          setComments(res.data.result);
+        });
+      });
+  };
+  const handleSubmit: React.MouseEventHandler<HTMLButtonElement> = (e) => {
+    if (userId === null) {
+      alert('로그인 후 이용해주세요');
+      return;
+    }
+    axios
+      .post(`${COMMENT_SERVER}`, {
+        writer: userId,
+        projectId: projectId,
+        content: msg,
+      })
+      .then((response) => {
+        if (!response.data.success) {
+          alert(`메시지 등록을 실패했습니다 (${response.data.err})`);
+          return;
+        }
+        axios.get(`${COMMENT_SERVER}/${projectId}`).then((res) => {
+          if (!res.data.success) {
+            alert(`Comment 정보를 가져오는 데 실패했습니다 (${res.data.err})`);
+            return;
+          }
+          setComments(res.data.result);
+          setMsg('');
+        });
+      });
+  };
+
+  useEffect(() => {
+    axios.get(`${COMMENT_SERVER}/${projectId}`).then((res) => {
+      if (!res.data.success) {
+        alert(`Comment 정보를 가져오는 데 실패했습니다 (${res.data.err})`);
+        return;
+      }
+      setComments(res.data.result);
+    });
+    if (userId !== null) {
+      axios.post(`${USER_SERVER}/info`, { _id: userId }).then((res) => {
+        if (!res.data.success) {
+          alert('회원 정보를 가져오지 못 했습니다');
+          return;
+        }
+        setNickname(res.data.user.nickname);
+        res.data.user.avartarImg
+          ? setAvartarImg(res.data.user.avartarImg)
+          : setAvartarImg(
+              'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_960_720.png'
+            );
+      });
+    }
+    return () => setComments([]);
+  }, []);
+
   return (
     <Container>
       <InputSection>
         <TabTitle>응원/질문을 올려주세요!</TabTitle>
         <InputWrap>
           <Thumb>
-            <Image src="https://letspl.me/assets/images/prof_noImg.svg" />
+            <Image src={avartarImg} alt="thumb" />
           </Thumb>
           <TextInput
             placeholder="프로젝트에 관한 질문이나 응원메시지를 올려주세요"
             maxLength={1000}
             rows={6}
+            value={msg}
+            onChange={handleChange}
           />
         </InputWrap>
         <ButtonWrapper>
@@ -76,10 +185,34 @@ const Question = () => {
             ButtonMode="active"
             ButtonName="등록"
             ButtonSize="medium"
+            onClick={handleSubmit}
           />
         </ButtonWrapper>
       </InputSection>
-      <Comment />
+      {comments.length ? (
+        comments.map((comment) => (
+          <Comment
+            avartarImg={comment.avartarImg}
+            content={comment.content}
+            nickname={comment.nickname}
+            time={new Date(comment.createdAt)}
+            key={comment.createdAt.toString()}
+            remove={
+              nickname === comment.nickname
+                ? () =>
+                    handleRemove(
+                      userId,
+                      projectId,
+                      comment.content,
+                      new Date(comment.createdAt)
+                    )
+                : undefined
+            }
+          />
+        ))
+      ) : (
+        <P></P>
+      )}
     </Container>
   );
 };

--- a/client/src/Components/Project/ProjectDetail/Status.tsx
+++ b/client/src/Components/Project/ProjectDetail/Status.tsx
@@ -1,6 +1,8 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import Button from '../../Common/Button';
+import axios from 'axios';
+import { MANAGE_SERVER, USER_SERVER } from '../../../Config';
 
 const Container = styled.div`
   border: 1px solid ${(props) => props.theme.palette.lightGray};
@@ -54,9 +56,74 @@ interface Ipos {
 
 interface IProps {
   position: Ipos[];
+  projectId: string;
 }
 
-const Status = ({ position }: IProps) => {
+const Status = ({ position, projectId }: IProps) => {
+  const userId = localStorage.getItem('userId');
+  const [pos, setPos] = useState('');
+  const [isJoin, setIsJoin] = useState('');
+
+  useEffect(() => {
+    if (userId !== null) {
+      axios.post(`${USER_SERVER}/info`, { _id: userId }).then((res) => {
+        if (!res.data.success) {
+          alert('회원 정보를 가져오지 못 했습니다');
+          return;
+        }
+        setPos(res.data.user.position);
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (userId !== null) {
+      axios
+        .post(`${MANAGE_SERVER}/find`, { pid: projectId, uid: userId })
+        .then((res) => {
+          if (res.data.success) {
+            setIsJoin(res.data.msg);
+          }
+        });
+    }
+  }, []);
+
+  const handleJoin = (
+    uid: string | null,
+    pid: string,
+    cur: number,
+    req: number,
+    position: string
+  ) => {
+    if (uid === null) {
+      alert('로그인 후 지원 가능합니다');
+      return;
+    }
+    if (cur === req) {
+      alert('더이상 지원할 수 없습니다');
+      return;
+    }
+    if (position !== pos) {
+      alert('지원할 수 없는 직무입니다');
+      return;
+    }
+    if (isJoin !== '') {
+      alert(isJoin);
+      return;
+    }
+    const msg = prompt('지원 이유');
+    if (msg !== null) {
+      axios
+        .post(`${MANAGE_SERVER}/join`, { uid: uid, pid: pid, msg: msg })
+        .then((res) => {
+          if (!res.data.success) {
+            alert(`프로젝트 지원 요청이 실패했습니다 (${res.data.err})`);
+            return;
+          }
+          alert('지원이 완료되었습니다');
+        });
+    }
+  };
   return (
     <Container>
       <Title>모집 현황</Title>
@@ -66,12 +133,23 @@ const Status = ({ position }: IProps) => {
             <Li key={item.pos}>
               <PostionText>{item.pos}</PostionText>
               <PositionNumber>{`${item.current}/${item.required}`}</PositionNumber>
-              <Button
-                ButtonColor="white"
-                ButtonMode="active"
-                ButtonName="지원"
-                ButtonSize="medium"
-              />
+              {item.current < item.required && (
+                <Button
+                  ButtonColor="white"
+                  ButtonMode="active"
+                  ButtonName="지원"
+                  ButtonSize="medium"
+                  onClick={() =>
+                    handleJoin(
+                      userId,
+                      projectId,
+                      item.current,
+                      item.required,
+                      item.pos
+                    )
+                  }
+                />
+              )}
             </Li>
           ))}
       </Ul>

--- a/client/src/Components/Project/ProjectDetail/UserInfo.tsx
+++ b/client/src/Components/Project/ProjectDetail/UserInfo.tsx
@@ -65,7 +65,14 @@ function UserInfo({
   return (
     <Container>
       <InfoBox>
-        <UserImg src={avatarImg} alt="Avartar" />
+        <UserImg
+          src={
+            avatarImg
+              ? avatarImg
+              : 'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_960_720.png'
+          }
+          alt="Avartar"
+        />
         <Info>
           <Text>{nickName}</Text>
           <Text>{pos}</Text>

--- a/client/src/Pages/Project/ProjectDetail/ProjectDetail.tsx
+++ b/client/src/Pages/Project/ProjectDetail/ProjectDetail.tsx
@@ -36,7 +36,7 @@ interface Ipos {
 const ProjectDetail = () => {
   const [currentTab, setCurrentTab] = useState(0);
   const { id } = useParams<{ id: string }>();
-  const [pid, setPid] = useState('');
+  const [pid, setPid] = useState(id);
   const [title, setTitle] = useState('');
   const [thumb, setThumb] = useState('');
   const [info, setInfo] = useState('');
@@ -51,6 +51,10 @@ const ProjectDetail = () => {
   const [receivedLike, setReceivedLike] = useState(0);
   const [avartarImg, setAvartarImg] = useState('');
   const [nickname, setNickname] = useState('');
+  const [uPos, setUPos] = useState('');
+  const [uPosLv, setUPosLv] = useState('');
+  const [uInterestSkills, setUInterestSkills] = useState([]);
+  const [uReceivedLike, setUReceivedLike] = useState(0);
   const [recruitment, setRecruitment] = useState(true);
   const userId = useRef(localStorage.getItem('userId'));
 
@@ -58,6 +62,29 @@ const ProjectDetail = () => {
     if (currentTab !== index) {
       setCurrentTab(index);
     }
+  };
+
+  const cleanup = () => {
+    setPid(id);
+    setTitle('');
+    setThumb('');
+    setInfo('');
+    setField('');
+    setArea('');
+    setPosition([]);
+    setReferenceURL([]);
+    setStartAt(new Date());
+    setEndAt(new Date());
+    setWriter('');
+    setProjectLV('');
+    setReceivedLike(0);
+    setAvartarImg('');
+    setNickname('');
+    setUPos('');
+    setUPosLv('');
+    setUInterestSkills([]);
+    setUReceivedLike(0);
+    setRecruitment(true);
   };
 
   useEffect(() => {
@@ -115,12 +142,24 @@ const ProjectDetail = () => {
           alert(`리더 정보를 가져오는데 실패했습니다 (${response.data.err})`);
           return;
         }
-        const { avartarImg, nickname } = response.data.user;
+        const {
+          avartarImg,
+          nickname,
+          position,
+          positionLevel,
+          interestSkills,
+          receivedLike,
+        } = response.data.user;
         setAvartarImg(avartarImg);
         setNickname(nickname);
+        setUPos(position);
+        setUPosLv(positionLevel);
+        setUInterestSkills(interestSkills);
+        setUReceivedLike(receivedLike);
       });
     });
-  }, []);
+    return () => cleanup();
+  }, [currentTab]);
 
   return (
     <Container>
@@ -140,9 +179,15 @@ const ProjectDetail = () => {
               referenceURL={referenceURL}
               nickname={nickname}
               position={position}
+              projectId={pid}
+              uPos={uPos}
+              uPosLv={uPosLv}
+              uInterestSkills={uInterestSkills}
+              uReceivedLike={uReceivedLike}
+              avartarImg={avartarImg}
             />
           )}
-          {currentTab === 1 && <Question />}
+          {currentTab === 1 && <Question projectId={pid} />}
           {currentTab === 2 && writer === userId.current && (
             <Management projectId={pid} />
           )}

--- a/client/src/Pages/Project/ProjectDetail/ProjectDetail.tsx
+++ b/client/src/Pages/Project/ProjectDetail/ProjectDetail.tsx
@@ -33,28 +33,61 @@ interface Ipos {
   current: number;
 }
 
+interface IProject {
+  _id: string;
+  title: string;
+  thumb: string;
+  info: string;
+  field: string;
+  area: string;
+  position: Ipos[];
+  referenceURL: string[];
+  startAt: Date;
+  endAt: Date;
+  writer: string;
+  projectLV: string;
+  receivedLike: number;
+}
+
+const initProject: IProject = {
+  _id: '',
+  title: '',
+  thumb: '',
+  info: '',
+  field: '',
+  area: '',
+  position: [],
+  referenceURL: [],
+  startAt: new Date(),
+  endAt: new Date(),
+  writer: '',
+  projectLV: '',
+  receivedLike: 0,
+};
+
+interface ILeader {
+  avartarImg: string;
+  nickname: string;
+  position: string;
+  positionLevel: string;
+  interestSkills: string[];
+  receivedLike: number;
+}
+
+const initLeader = {
+  avartarImg: '',
+  nickname: '',
+  position: '',
+  positionLevel: '',
+  interestSkills: [],
+  receivedLike: 0,
+};
+
 const ProjectDetail = () => {
   const [currentTab, setCurrentTab] = useState(0);
   const { id } = useParams<{ id: string }>();
-  const [pid, setPid] = useState(id);
-  const [title, setTitle] = useState('');
-  const [thumb, setThumb] = useState('');
-  const [info, setInfo] = useState('');
-  const [field, setField] = useState('');
-  const [area, setArea] = useState('');
-  const [position, setPosition] = useState<Ipos[]>([]);
-  const [referenceURL, setReferenceURL] = useState<string[]>([]);
-  const [startAt, setStartAt] = useState<Date>(new Date());
-  const [endAt, setEndAt] = useState<Date>(new Date());
-  const [writer, setWriter] = useState('');
-  const [projectLV, setProjectLV] = useState('');
-  const [receivedLike, setReceivedLike] = useState(0);
-  const [avartarImg, setAvartarImg] = useState('');
-  const [nickname, setNickname] = useState('');
-  const [uPos, setUPos] = useState('');
-  const [uPosLv, setUPosLv] = useState('');
-  const [uInterestSkills, setUInterestSkills] = useState([]);
-  const [uReceivedLike, setUReceivedLike] = useState(0);
+  const [project, setProject] = useState<IProject>(initProject);
+  const [leader, setLeader] = useState<ILeader>(initLeader);
   const [recruitment, setRecruitment] = useState(true);
   const userId = useRef(localStorage.getItem('userId'));
 
@@ -65,30 +98,13 @@ const ProjectDetail = () => {
   };
 
   const cleanup = () => {
-    setPid(id);
-    setTitle('');
-    setThumb('');
-    setInfo('');
-    setField('');
-    setArea('');
-    setPosition([]);
-    setReferenceURL([]);
-    setStartAt(new Date());
-    setEndAt(new Date());
-    setWriter('');
-    setProjectLV('');
-    setReceivedLike(0);
-    setAvartarImg('');
-    setNickname('');
-    setUPos('');
-    setUPosLv('');
-    setUInterestSkills([]);
-    setUReceivedLike(0);
+    setProject(initProject);
+    setLeader(initLeader);
     setRecruitment(true);
   };
 
   useEffect(() => {
-    if (currentTab === 2 && writer !== userId.current) {
+    if (currentTab === 2 && project.writer !== userId.current) {
       alert('접근 권한이 없습니다');
       setCurrentTab(0);
     }
@@ -116,27 +132,33 @@ const ProjectDetail = () => {
         receivedLike,
       } = res.data.project;
 
-      setPid(_id);
-      setTitle(title);
-      setThumb(thumb);
-      axios.get(`${info}`).then((response) => {
-        setInfo(response.data);
+      setProject({
+        _id,
+        title,
+        thumb,
+        info: '',
+        field,
+        area,
+        position,
+        referenceURL,
+        startAt: new Date(startAt),
+        endAt: new Date(endAt),
+        writer,
+        projectLV,
+        receivedLike,
       });
-      setField(field);
-      setArea(area);
-      setPosition(position);
+
+      axios.get(`${info}`).then((response) => {
+        setProject((prev) => ({ ...prev, info: response.data }));
+      });
+
       setRecruitment(
         !position.reduce(
           (acc: boolean, v: any) => acc && v['current'] === v['required'],
           true
         )
       );
-      setReferenceURL(referenceURL);
-      setStartAt(new Date(startAt));
-      setEndAt(new Date(endAt));
-      setWriter(writer);
-      setProjectLV(projectLV);
-      setReceivedLike(receivedLike);
+
       axios.post(`${USER_SERVER}/info`, { _id: writer }).then((response) => {
         if (!response.data.user) {
           alert(`리더 정보를 가져오는데 실패했습니다 (${response.data.err})`);
@@ -150,62 +172,69 @@ const ProjectDetail = () => {
           interestSkills,
           receivedLike,
         } = response.data.user;
-        setAvartarImg(avartarImg);
-        setNickname(nickname);
-        setUPos(position);
-        setUPosLv(positionLevel);
-        setUInterestSkills(interestSkills);
-        setUReceivedLike(receivedLike);
+
+        setLeader({
+          avartarImg,
+          nickname,
+          position,
+          positionLevel,
+          interestSkills,
+          receivedLike,
+        });
       });
     });
-    return () => cleanup();
   }, [currentTab]);
+
+  useEffect(() => {
+    return () => cleanup();
+  }, []);
 
   return (
     <Container>
       <ProjectDtailHeader
-        field={field}
-        nickname={nickname}
+        field={project.field}
+        nickname={leader.nickname}
         recruitment={recruitment}
-        avartarImg={avartarImg}
-        title={title}
+        avartarImg={leader.avartarImg}
+        title={project.title}
       />
       <ProjectPageWrap>
         <Contents>
           <ProjectTab current={currentTab} onClick={handleChangeTab} />
           {currentTab === 0 && (
             <Info
-              info={info}
-              referenceURL={referenceURL}
-              nickname={nickname}
-              position={position}
-              projectId={pid}
-              uPos={uPos}
-              uPosLv={uPosLv}
-              uInterestSkills={uInterestSkills}
-              uReceivedLike={uReceivedLike}
-              avartarImg={avartarImg}
+              info={project.info}
+              referenceURL={project.referenceURL}
+              nickname={leader.nickname}
+              position={project.position}
+              projectId={id}
+              uPos={leader.position}
+              uPosLv={leader.positionLevel}
+              uInterestSkills={leader.interestSkills}
+              uReceivedLike={leader.receivedLike}
+              avartarImg={leader.avartarImg}
             />
           )}
-          {currentTab === 1 && <Question projectId={pid} />}
-          {currentTab === 2 && writer === userId.current && (
-            <Management projectId={pid} />
+          {currentTab === 1 && <Question projectId={id} />}
+          {currentTab === 2 && project.writer === userId.current && (
+            <Management projectId={id} />
           )}
         </Contents>
         <RightMenu
-          avartarImg={avartarImg}
-          endAt={`${endAt.getFullYear()}/${
-            endAt.getMonth() + 1
-          }/${endAt.getDate()}`}
-          startAt={`${startAt.getFullYear()}/${
-            startAt.getMonth() + 1
-          }/${startAt.getDate()}`}
+          avartarImg={leader.avartarImg}
+          endAt={`${project.endAt.getFullYear()}/${
+            project.endAt.getMonth() + 1
+          }/${project.endAt.getDate()}`}
+          startAt={`${project.startAt.getFullYear()}/${
+            project.startAt.getMonth() + 1
+          }/${project.startAt.getDate()}`}
           date={`${Math.ceil(
-            (endAt.getTime() - startAt.getTime()) / (1000 * 3600 * 24)
+            (project.endAt.getTime() - project.startAt.getTime()) /
+              (1000 * 3600 * 24)
           )}`}
-          field={field}
-          nickname={nickname}
-          receivedLike={receivedLike}
+          field={project.field}
+          nickname={leader.nickname}
+          receivedLike={project.receivedLike}
         />
       </ProjectPageWrap>
     </Container>

--- a/server/models/Comment.ts
+++ b/server/models/Comment.ts
@@ -1,22 +1,22 @@
 import mongoose, { Schema, Model } from 'mongoose';
-import {IComment} from './Commet.interface';
+import { IComment } from './Commet.interface';
 
-const CommentSchema: mongoose.Schema<IComment> = new Schema(
-  {
-    writer: {
-        type: Schema.Types.ObjectId,
-        ref: 'User'
-    },
-    ProjectId: {
-        type: Schema.Types.ObjectId,
-        ref: 'Project'
-    },
-},
-  {
-    timestamps: true,
-  }
+const CommentSchema: mongoose.Schema<IComment> = new Schema({
+  writer: {
+    type: Schema.Types.ObjectId,
+    ref: 'User',
+  },
+  projectId: {
+    type: Schema.Types.ObjectId,
+    ref: 'Project',
+  },
+  content: String,
+  createdAt: { type: Date, default: Date.now },
+});
+
+export const Comment: Model<IComment> = mongoose.model(
+  'comment',
+  CommentSchema
 );
-
-export const Comment: Model<IComment> = mongoose.model('comment', CommentSchema);
 
 export default Comment;

--- a/server/models/Commet.interface.ts
+++ b/server/models/Commet.interface.ts
@@ -2,5 +2,7 @@ import { Document, Schema } from 'mongoose';
 
 export interface IComment extends Document {
   writer: Schema.Types.ObjectId;
-  ProjectId: Schema.Types.ObjectId;
+  projectId: Schema.Types.ObjectId;
+  content: string;
+  createdAt: Date;
 }

--- a/server/models/UserRole.interface.ts
+++ b/server/models/UserRole.interface.ts
@@ -2,6 +2,7 @@ import { Document, Schema } from 'mongoose';
 
 export interface IUserRole extends Document {
   projectId: Schema.Types.ObjectId;
-  userId: Schema.Types.ObjectId
+  userId: Schema.Types.ObjectId;
   role: Number;
+  msg?: string;
 }

--- a/server/models/UserRole.ts
+++ b/server/models/UserRole.ts
@@ -1,22 +1,27 @@
 import mongoose, { Schema, Model } from 'mongoose';
-import {IUserRole} from './UserRole.interface';
+import { IUserRole } from './UserRole.interface';
 
 const userRoleSchema: mongoose.Schema<IUserRole> = new Schema(
   {
     projectId: {
       type: Schema.Types.ObjectId,
-      ref: 'project'
+      ref: 'project',
     },
     userId: {
       type: Schema.Types.ObjectId,
-      ref: 'user'
+      ref: 'user',
     },
-    role: Number},
+    role: Number,
+    msg: String,
+  },
   {
     timestamps: true,
   }
 );
 
-export const UserRole: Model<IUserRole> = mongoose.model('user_role', userRoleSchema);
+export const UserRole: Model<IUserRole> = mongoose.model(
+  'user_role',
+  userRoleSchema
+);
 
 export default UserRole;

--- a/server/routes/Comment.ts
+++ b/server/routes/Comment.ts
@@ -1,9 +1,47 @@
-import express, { Request, Response } from "express";
+import express, { Request, Response } from 'express';
+const { User } = require('../models/User');
+import { IUserMethods } from '../models/User.interface';
+const { Comment } = require('../models/Comment');
+import { IComment } from '../models/Commet.interface';
 
 const router = express.Router();
 
-router.get("/",(req: Request, res: Response) => {
-  
+router.get('/', (req: Request, res: Response) => {});
+
+router.post('/', (req: Request, res: Response) => {
+  const cmt = new Comment(req.body);
+  cmt.save((err: Error | null, comment: IComment) => {
+    if (err) return res.json({ success: false, err });
+    return res.status(200).json({ success: true, comment });
+  });
 });
 
-module.exports =router;
+router.post('/remove', (req: Request, res: Response) => {
+  Comment.deleteOne(req.body, (err: Error, cmt: IComment) => {
+    if (err) return res.json({ success: false, err });
+    return res.status(200).json({ success: true });
+  });
+});
+
+router.get('/:pid', (req: Request, res: Response) => {
+  Comment.find({ projectId: req.params.pid })
+    .sort({ createdAt: -1 })
+    .exec((err: Error, comments: IComment[]) => {
+      if (err) return res.json({ success: false, err });
+      Promise.all(comments.map((cmt) => User.findOne({ _id: cmt.writer })))
+        .then((results) => {
+          const mappedResults = results.map((user, idx) => ({
+            nickname: user.nickname,
+            avartarImg: user.avartarImg,
+            createdAt: comments[idx].createdAt,
+            content: comments[idx].content,
+          }));
+          return res.status(200).json({ success: true, result: mappedResults });
+        })
+        .catch((err) => {
+          return res.json({ success: false, err });
+        });
+    });
+});
+
+module.exports = router;

--- a/server/routes/ManageProject.ts
+++ b/server/routes/ManageProject.ts
@@ -9,6 +9,134 @@ router.get('/', (req: Request, res: Response) => {
   res.send('hello manage!');
 });
 
+router.post('/find', (req: Request, res: Response) => {
+  UserRole.findOne(
+    { projectId: req.body.pid, userId: req.body.uid },
+    (err: Error, role: IUserRole) => {
+      if (err) return res.json({ success: false, err });
+      let msg = '';
+      switch (role.role) {
+        case 0:
+          msg = '이미 해당 프로젝트의 리더입니다';
+          break;
+        case 1:
+          msg = '이미 해당 프로젝트의 멤버입니다';
+          break;
+        case 2:
+          msg = '이미 해당 프로젝트에 지원했습니다';
+          break;
+      }
+      return res.json({ success: true, msg });
+    }
+  );
+});
+
+router.post('/join', (req: Request, res: Response) => {
+  const userRole = new UserRole({
+    projectId: req.body.pid,
+    userId: req.body.uid,
+    role: 2,
+    msg: req.body.msg,
+  });
+  userRole.save((err: Error | null, doc: IUserRole) => {
+    if (err) {
+      return res.json({ success: false, err });
+    }
+    return res.status(200).json({
+      success: true,
+    });
+  });
+});
+
+router.post('/accept', (req: Request, res: Response) => {
+  Project.findOne({ _id: req.body.pid }, (err: Error, prj: IProject) => {
+    if (err) {
+      return res.json({ success: false, err });
+    }
+    let isFull = false;
+    prj.position = prj.position.map((item) => {
+      if (item.pos === req.body.pos) {
+        if (item.current < item.required) item.current += 1;
+        else isFull = true;
+      }
+      return item;
+    });
+    if (isFull) {
+      return res.json({ success: false, err: '모집 인원이 다 찼습니다' });
+    }
+    Project.findOneAndUpdate(
+      { _id: req.body.pid },
+      { $set: { position: prj.position } },
+      (err: Error, prev: IProject) => {
+        if (err) return res.json({ success: false, err });
+        UserRole.findOneAndUpdate(
+          {
+            projectId: req.body.pid,
+            userId: req.body.uid,
+            role: 2,
+          },
+          { $set: { role: 1 } },
+          (err: Error, userRole: IUserRole) => {
+            if (err) {
+              return res.json({ success: false, err });
+            }
+            return res.status(200).json({
+              success: true,
+            });
+          }
+        );
+      }
+    );
+  });
+});
+
+router.post('/reject', (req: Request, res: Response) => {
+  UserRole.deleteOne(
+    { projectId: req.body.pid, userId: req.body.uid, role: 2 },
+    (err: Error, userRole: IUserRole) => {
+      if (err) return res.json({ success: false, err });
+      return res.status(200).json({
+        success: true,
+      });
+    }
+  );
+});
+
+router.post('/remove', (req: Request, res: Response) => {
+  Project.findOne({ _id: req.body.pid }, (err: Error, prj: IProject) => {
+    if (err) {
+      return res.json({ success: false, err });
+    }
+    let isEmpty = false;
+    prj.position = prj.position.map((item) => {
+      if (item.pos === req.body.pos) {
+        if (item.current > 0) item.current -= 1;
+        else isEmpty = true;
+      }
+      return item;
+    });
+    if (isEmpty) {
+      return res.json({ success: false, err: '더 이상 삭제할 수 없습니다' });
+    }
+    Project.findOneAndUpdate(
+      { _id: req.body.pid },
+      { $set: { position: prj.position } },
+      (err: Error, prev: IProject) => {
+        if (err) return res.json({ success: false, err });
+        UserRole.deleteOne(
+          { projectId: req.body.pid, userId: req.body.uid, role: 1 },
+          (err: Error, userRole: IUserRole) => {
+            if (err) return res.json({ success: false, err });
+            return res.status(200).json({
+              success: true,
+            });
+          }
+        );
+      }
+    );
+  });
+});
+
 router.post('/updateProject', (req: Request, res: Response) => {
   Project.findOneAndUpdate(
     { _id: req.body._id },

--- a/server/routes/Project.ts
+++ b/server/routes/Project.ts
@@ -4,6 +4,8 @@ const router = express.Router();
 const multer = require('multer');
 const { Project } = require('../models/Project');
 import { IProject } from '../models/Project.interface';
+const { User } = require('../models/User');
+import { IUserMethods } from '../models/User.interface';
 const { UserRole } = require('../models/UserRole');
 import { IUserRole } from '../models/UserRole.interface';
 const fs = require('fs');
@@ -74,6 +76,69 @@ router.post('/info', (req: Request, res: Response) => {
       project,
     });
   });
+});
+
+router.get('/joinList/:id', (req: Request, res: Response) => {
+  UserRole.find(
+    { projectId: req.params.id, role: 2 },
+    (err: Error, role: IUserRole[]) => {
+      if (err) {
+        return res.json({
+          success: false,
+          err,
+        });
+      }
+      // role 배열에 담긴 유저아이디 참조해서 유저 정보 배열 구한 뒤 결과로 보내기
+      Promise.all(role.map((r) => User.findOne({ _id: r.userId })))
+        .then((result) => {
+          const mappedResult = result.map((item, idx) => ({
+            item,
+            msg: role[idx].msg,
+          }));
+          return res.status(200).json({
+            success: true,
+            result: mappedResult,
+          });
+        })
+        .catch((err) =>
+          res.status(200).json({
+            success: false,
+            err,
+          })
+        );
+    }
+  );
+});
+
+router.get('/memberList/:id', (req: Request, res: Response) => {
+  UserRole.find(
+    { projectId: req.params.id, role: 1 },
+    (err: Error, role: IUserRole[]) => {
+      if (err) {
+        return res.json({
+          success: false,
+          err,
+        });
+      }
+      // role 배열에 담긴 유저아이디 참조해서 유저 정보 배열 구한 뒤 결과로 보내기
+      Promise.all(role.map((r) => User.findOne({ _id: r.userId })))
+        .then((result) => {
+          const mappedResult = result.map((item, idx) => ({
+            item,
+          }));
+          return res.status(200).json({
+            success: true,
+            result: mappedResult,
+          });
+        })
+        .catch((err) =>
+          res.status(200).json({
+            success: false,
+            err,
+          })
+        );
+    }
+  );
 });
 
 router.get('/recommendList', (req: Request, res: Response) => {


### PR DESCRIPTION
## 개요

- 프로젝트 디테일 페이지 3개 탭 기능 구현
- resolve: #132 
 
## 작업 내용

1. 정보탭
- 지원 버튼이 활성화 상태면 조건 통과 시 모달 창에서 지원 사유 입력 후 '지원이 완료되었습니다.' 팝업
( 조건 : 로그인 유무, 직무 일치 여부, 이미 팀장/멤버/지원 상태인지 여부 )
- 팀원이 꽉찬 상태면 지원 버튼 비활성화
- 리더 정보 및 참가한 멤버들의 정보 표시
2. 질문탭
- 질문 등록 ( 로그인 후 사용 가능 )
- 현재 프로젝트의 질문 가져오기( 날짜 최신 순으로 보여주기 )
- 질문 쓴 사람은 삭제 가능
3. 관리탭
- 지원 현황 리스트 표시 및 수락/거절 기능
- 현재 멤버 리스트 표시 및 삭제 기능
4. 공통
- Config.ts에 COMMENT_SERVER = '/api/comment'; 추가

## 스크린샷
