### PR TITLE
feat: 프로젝트 지원 및 질문 시 알람 기능 추가

### DIFF
--- a/client/src/Components/Project/ProjectDetail/Info.tsx
+++ b/client/src/Components/Project/ProjectDetail/Info.tsx
@@ -85,7 +85,7 @@ const Info = ({
       }
       setMemberList(res.data.result);
     });
-  }, [memberList]);
+  }, []);
 
   useEffect(() => {
     return () => setMemberList([]);
@@ -94,7 +94,7 @@ const Info = ({
   return (
     <Container>
       <Section>
-        <Status position={position} projectId={projectId} />
+        <Status position={position} projectId={projectId} leaderId={leaderId} />
       </Section>
       <Section>
         <TabTitle>- 소개</TabTitle>

--- a/client/src/Components/Project/ProjectDetail/Question.tsx
+++ b/client/src/Components/Project/ProjectDetail/Question.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import Comment from './Comment';
 import Button from '../../Common/Button';
 import axios from 'axios';
-import { COMMENT_SERVER, USER_SERVER } from '../../../Config';
+import { COMMENT_SERVER, USER_SERVER, ALARM_SERVER } from '../../../Config';
 
 const Container = styled.div``;
 
@@ -63,6 +63,7 @@ const P = styled.p`
 
 interface IProps {
   projectId: string;
+  leaderId: string;
 }
 
 interface IComment {
@@ -72,7 +73,7 @@ interface IComment {
   content: string;
 }
 
-const Question = ({ projectId }: IProps) => {
+const Question = ({ projectId, leaderId }: IProps) => {
   const userId = localStorage.getItem('userId');
   const [comments, setComments] = useState<IComment[]>([]);
   const [msg, setMsg] = useState('');
@@ -126,6 +127,18 @@ const Question = ({ projectId }: IProps) => {
         if (!response.data.success) {
           alert(`메시지 등록을 실패했습니다 (${response.data.err})`);
           return;
+        }
+        if (userId !== leaderId) {
+          axios
+            .post(`${ALARM_SERVER}/comment`, { sid: userId, rid: leaderId })
+            .then((res) => {
+              if (!res.data.success) {
+                alert(
+                  `프로젝트 리더에게 질문 알람을 보내는 데 실패했습니다 (${res.data.err})`
+                );
+                return;
+              }
+            });
         }
         axios.get(`${COMMENT_SERVER}/${projectId}`).then((res) => {
           if (!res.data.success) {

--- a/client/src/Components/Project/ProjectDetail/Status.tsx
+++ b/client/src/Components/Project/ProjectDetail/Status.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import Button from '../../Common/Button';
 import axios from 'axios';
-import { MANAGE_SERVER, USER_SERVER } from '../../../Config';
+import { MANAGE_SERVER, USER_SERVER, ALARM_SERVER } from '../../../Config';
 
 const Container = styled.div`
   border: 1px solid ${(props) => props.theme.palette.lightGray};
@@ -57,9 +57,10 @@ interface Ipos {
 interface IProps {
   position: Ipos[];
   projectId: string;
+  leaderId: string;
 }
 
-const Status = ({ position, projectId }: IProps) => {
+const Status = ({ position, projectId, leaderId }: IProps) => {
   const userId = localStorage.getItem('userId');
   const [pos, setPos] = useState('');
   const [isJoin, setIsJoin] = useState('');
@@ -120,6 +121,16 @@ const Status = ({ position, projectId }: IProps) => {
             alert(`프로젝트 지원 요청이 실패했습니다 (${res.data.err})`);
             return;
           }
+          axios
+            .post(`${ALARM_SERVER}/apply`, { sid: uid, rid: leaderId })
+            .then((response) => {
+              if (!response.data.success) {
+                alert(
+                  `프로젝트 리더에게 지원 요청 알람을 보내는 데 실패했습니다 (${response.data.err})`
+                );
+                return;
+              }
+            });
           alert('지원이 완료되었습니다');
         });
     }

--- a/client/src/Pages/Project/ProjectDetail/ProjectDetail.tsx
+++ b/client/src/Pages/Project/ProjectDetail/ProjectDetail.tsx
@@ -220,7 +220,9 @@ const ProjectDetail = () => {
               avartarImg={leader.avartarImg}
             />
           )}
-          {currentTab === 1 && <Question projectId={id} />}
+          {currentTab === 1 && (
+            <Question projectId={id} leaderId={leader._id} />
+          )}
           {currentTab === 2 && project.writer === userId.current && (
             <Management projectId={id} />
           )}

--- a/server/models/Alarm.interface.ts
+++ b/server/models/Alarm.interface.ts
@@ -1,0 +1,9 @@
+import { Document, Schema } from 'mongoose';
+
+export interface IAlarm extends Document {
+  senderId: Schema.Types.ObjectId;
+  receivedId: Schema.Types.ObjectId;
+  isRead: boolean;
+  Contents: string;
+  type: number;
+}

--- a/server/models/Alarm.ts
+++ b/server/models/Alarm.ts
@@ -1,0 +1,25 @@
+import mongoose, { Schema, Model } from 'mongoose';
+import { IAlarm } from './Alarm.interface';
+
+const AlarmSchema: mongoose.Schema<IAlarm> = new Schema(
+  {
+    senderId: {
+      type: Schema.Types.ObjectId,
+      ref: 'user',
+    },
+    receivedId: {
+      type: Schema.Types.ObjectId,
+      ref: 'user',
+    },
+    isRead: Boolean,
+    Contents: String,
+    type: Number,
+  },
+  {
+    timestamps: true,
+  }
+);
+
+export const Alarm: Model<IAlarm> = mongoose.model('alarm', AlarmSchema);
+
+export default Alarm;

--- a/server/routes/Alarm.ts
+++ b/server/routes/Alarm.ts
@@ -1,9 +1,37 @@
-import express, { Request, Response } from "express";
+import express, { Request, Response } from 'express';
+import { Alarm } from '../models/Alarm';
+import { IAlarm } from '../models/Alarm.interface';
 
 const router = express.Router();
 
-router.get("/",(req: Request, res: Response) => {
-  
+router.get('/', (req: Request, res: Response) => {});
+
+router.post('/apply', (req: Request, res: Response) => {
+  const alarm = new Alarm({
+    senderId: req.body.sid,
+    receivedId: req.body.rid,
+    isRead: false,
+    Contents: `프로젝트에 지원 요청이 왔습니다`,
+    type: 2,
+  });
+  alarm.save((err: Error | null, doc: IAlarm) => {
+    if (err) return res.json({ success: false, err });
+    return res.status(200).json({ success: true });
+  });
 });
 
-module.exports =router;
+router.post('/comment', (req: Request, res: Response) => {
+  const alarm = new Alarm({
+    senderId: req.body.sid,
+    receivedId: req.body.rid,
+    isRead: false,
+    Contents: `프로젝트에 질문이 왔습니다`,
+    type: 3,
+  });
+  alarm.save((err: Error | null, doc: IAlarm) => {
+    if (err) return res.json({ success: false, err });
+    return res.status(200).json({ success: true });
+  });
+});
+
+module.exports = router;

--- a/server/routes/ManageProject.ts
+++ b/server/routes/ManageProject.ts
@@ -17,7 +17,7 @@ router.post('/find', (req: Request, res: Response) => {
     (err: Error, role: IUserRole) => {
       if (err) return res.json({ success: false, err });
       let msg = '';
-      switch (role.role) {
+      switch (role?.role) {
         case 0:
           msg = '이미 해당 프로젝트의 리더입니다';
           break;


### PR DESCRIPTION
## 개요

- 프로젝트 지원 또는 질문 시 해당 프로젝트 리더에게 알람 보냄
- resolve: #143 
 
## 작업 내용

- 누군가 프로젝트 지원 시 리더에게 알람을 보냄
- 누군가 프로젝트에 질문을 달면 리더에게 알람을 보냄
- Config.ts에 export const ALARM_SERVER = '/api/alarm'; 추가

## 스크린샷
